### PR TITLE
New Permissions and remove a module

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -10,30 +10,10 @@
         "--socket=wayland",
         "--device=dri",
         "--talk-name=org.freedesktop.Flatpak",
-        "--filesystem=~/.local/share/applications:ro"
+        "--filesystem=~/.local/share/applications:ro",
+        "--filesystem=~/.local/share/icons/distrobox:ro"
     ],
     "modules": [
-        {
-            "name": "kirigami-addons",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF"
-            ],
-            "builddir": true,
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.9.0.tar.xz",
-                    "sha256": "21314a91f26b1c962def3fd7ff2e762d3358b075f63f4d7e0144fb2c63b7ebc7",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 242933,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-                    }
-                }
-            ]
-        },
         {
             "name": "kontainer",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Now Kontainer reads ~/.local/share/icons/distrobox/ to visually show icons for the distroboxes and kirigami-addons was added into the kde sdk 6.9 so no need to build kirigami-addons anymore.