### PR TITLE
Chore: Release 1.4.1

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -24,9 +24,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://invent.kde.org/denysmb/Kontainer.git",
-                    "tag": "1.4.0",
-                    "commit": "31e12aa5bfa88f5cdb0b09f5cdfd077d75b3da66"
+                    "url": "https://github.com/DenysMb/Kontainer.git",
+                    "tag": "1.4.1",
+                    "commit": "bac90f1aa49a1fb465e445da156686964f4a7882"
                 }
             ]
         }


### PR DESCRIPTION
Chaging it back to Github as KDE Invent doesn't allow to commit .po/.pot, so I couldn't update the translations.