### PR TITLE
chore: bump to 6.10 runtime

### DIFF
--- a/io.github.DenysMb.Kontainer.json
+++ b/io.github.DenysMb.Kontainer.json
@@ -1,7 +1,7 @@
 {
-    "app-id": "io.github.DenysMb.Kontainer",
+    "id": "io.github.DenysMb.Kontainer",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "kontainer",
     "finish-args": [


### PR DESCRIPTION
app-id is deprecated